### PR TITLE
change defqueries to return table of fns

### DIFF
--- a/sql/one.sql
+++ b/sql/one.sql
@@ -1,0 +1,3 @@
+-- name: one
+-- fn: first
+select 14

--- a/src/suresql/init.janet
+++ b/src/suresql/init.janet
@@ -97,9 +97,8 @@
 
     (loop [q :in queries]
       (let [{"name" name} q
-            name (symbol name)
             q-fn (query-fn connection q)]
-        (defglobal name q-fn)
+        (defglobal (symbol name) q-fn)
         (put connected-queries
              (keyword name)
              q-fn)))

--- a/src/suresql/init.janet
+++ b/src/suresql/init.janet
@@ -92,8 +92,15 @@
 (defn defqueries [sql-file &opt options]
   (let [queries (->> (slurp sql-file)
                      (parse-queries))
-        connection (get options :connection)]
+        connection (get options :connection)
+        connected-queries @{}]
 
     (loop [q :in queries]
-      (let [{"name" name} q]
-        (defglobal (symbol name) (query-fn connection q))))))
+      (let [{"name" name} q
+            name (symbol name)
+            q-fn (query-fn connection q)]
+        (defglobal name q-fn)
+        (put connected-queries
+             (keyword name)
+             q-fn)))
+    connected-queries))

--- a/test/suresql/local-binding-test.janet
+++ b/test/suresql/local-binding-test.janet
@@ -1,0 +1,13 @@
+(import ../../src/suresql)
+(import ./users)
+(import tester :prefix "" :exit true)
+(import sqlite3 :as sqlite)
+
+
+(defsuite "local bindings"
+  (def fns (suresql/defqueries "sql/one.sql"
+                               {:connection (sqlite/open "test.db")}))
+
+  (test "defquery returns functions"
+        (is (deep= @{:14 14}
+                   ((fns :one) {})))))

--- a/test/suresql/pq-users.janet
+++ b/test/suresql/pq-users.janet
@@ -1,4 +1,4 @@
-(import "src/suresql/init" :prefix "")
+(import ../../src/suresql :prefix "")
 
 (var pq/connect identity)
 (def database-url "postgres://localhost:5432/suresql_test_db")

--- a/test/suresql/users-2.janet
+++ b/test/suresql/users-2.janet
@@ -1,4 +1,4 @@
-(import "src/suresql/init" :prefix "")
+(import ../../src/suresql :prefix "")
 
 (def database-url "users-2.sqlite3")
 

--- a/test/suresql/users.janet
+++ b/test/suresql/users.janet
@@ -1,4 +1,4 @@
-(import "src/suresql/init" :prefix "")
+(import ../../src/suresql :prefix "")
 
 (var sqlite3/open identity)
 (def database-url "test.sqlite3")


### PR DESCRIPTION
This changes `suresql/defqueries` to return a table of queries, as well as defining them globally. I considered using a :local flag in the options struct to switch between the two, but since the return value is currently always nil I don't believe this breaks any of the API. I can still switch it back to that if it's preferable though.

Uses:
* Queries can be passed around in normal bindings as function arguments, in app middleware, etc instead of in dynamics. This is my use case, since circlet wipes dynamics even if `with-dyns` is used.
* Can bind queries "as needed" rather than up front, which can simply code using threads. The db connection can't be marshaled across a thread boundary (and would probably be a bad idea anyway see [2.6](https://www.sqlite.org/howtocorrupt.html)). Having the functions available in lexical scope gives more options for how to mitigate that.
  * Another approach could be to separate query parsing and binding them to a connection. They could take the connection at invocation time. This felt like a significant change to the approach. I think the API could be kept the same by using partial application carefully, but it would be more complex than what I did here.

I don't know why I had to change the imports in the tests, I was getting "could not find module" errors. I'm new to janet and have only used import with a relative path symbol, not a string. Maybe it's just an incompatibility with an older version? I'm on 1.25.1-meson. Again if that style is preferred I'm happy to change it back.